### PR TITLE
Add support for --claude-path parameter configuration

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -72,12 +72,14 @@ export class ClaudeAcpAgent implements Agent {
   fileContentCache: { [key: string]: string };
   backgroundTerminals: { [key: string]: BackgroundTerminal } = {};
   clientCapabilities?: ClientCapabilities;
+  claudePath?: string;
 
-  constructor(client: AgentSideConnection) {
+  constructor(client: AgentSideConnection, claudePath?: string) {
     this.sessions = {};
     this.client = client;
     this.toolUseCache = {};
     this.fileContentCache = {};
+    this.claudePath = claudePath;
   }
 
   async initialize(request: InitializeRequest): Promise<InitializeResponse> {
@@ -157,6 +159,8 @@ export class ClaudeAcpAgent implements Agent {
       // note: although not documented by the types, passing an absolute path
       // here works to find zed's managed node version.
       executable: process.execPath as any,
+      // Support custom Claude path
+      ...(this.claudePath && { pathToClaudeCodeExecutable: this.claudePath }),
     };
 
     const allowedTools = [];
@@ -590,9 +594,9 @@ export function toAcpNotifications(
   return output;
 }
 
-export function runAcp() {
+export function runAcp(claudePath?: string) {
   new AgentSideConnection(
-    (client) => new ClaudeAcpAgent(client),
+    (client) => new ClaudeAcpAgent(client, claudePath),
     nodeToWebWritable(process.stdout),
     nodeToWebReadable(process.stdin),
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,14 @@ process.on("unhandledRejection", (reason, promise) => {
   console.error("Unhandled Rejection at:", promise, "reason:", reason);
 });
 
+// Parse command line arguments for Claude path
+const claudePathIndex = process.argv.indexOf('--claude-path');
+const claudePath = claudePathIndex !== -1 && claudePathIndex + 1 < process.argv.length 
+  ? process.argv[claudePathIndex + 1] 
+  : undefined;
+
 import { runAcp as runAcp } from "./acp-agent.js";
-runAcp();
+runAcp(claudePath);
 
 // Keep process alive
 process.stdin.resume();


### PR DESCRIPTION
## Summary
- Add optional `--claude-path` command line parameter support
- Allow configuring `pathToClaudeCodeExecutable` in SDK options for custom binary paths
- Maintain full backward compatibility with existing default behavior

## Changes
- **src/index.ts**: Parse command line arguments for `--claude-path` parameter
- **src/acp-agent.ts**: Add claudePath property and pass to SDK configuration

## Test plan
- [x] Build process works correctly
- [x] Backward compatibility maintained (no parameters = default behavior)  
- [x] Custom path properly passed to SDK via `pathToClaudeCodeExecutable`
- [x] npm link functionality verified